### PR TITLE
WIP: Add "Accept" header parser

### DIFF
--- a/src/Header/AcceptHeader.php
+++ b/src/Header/AcceptHeader.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Pavel Z
+ */
+
+declare(strict_types=1);
+
+namespace Spiral\Http\Header;
+
+/**
+ * Can be used for parsing and sorting "Accept*" header items by preferable by the HTTP client.
+ *
+ * Supported headers:
+ *   Accept
+ *   Accept-Encoding
+ *   Accept-Charset
+ *   Accept-Language
+ */
+final class AcceptHeader
+{
+    /** @var array|AcceptHeaderItem[] */
+    private $items = [];
+
+    /** @var bool */
+    private $sorted = true;
+
+    /**
+     * @param string $raw
+     * @return AcceptHeader
+     */
+    public static function fromString(string $raw): self
+    {
+        $header = new static();
+        $header->sorted = false;
+
+        $parts = explode(',', $raw);
+        foreach ($parts as $part) {
+            $header->addItem(trim($part));
+        }
+
+        return $header;
+    }
+
+    /**
+     * AcceptHeader constructor.
+     * @param array|AcceptHeaderItem[]|string[] $items
+     */
+    public function __construct(array $items = [])
+    {
+        foreach ($items as $item) {
+            $this->addItem($item);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return implode(', ', $this->sorted());
+    }
+
+    /**
+     * @param AcceptHeaderItem|string $item
+     * @return $this
+     */
+    public function add($item): self
+    {
+        $header = clone $this;
+        $header->addItem($item);
+
+        return $header;
+    }
+
+    /**
+     * @param string $value
+     * @return bool
+     */
+    public function has(string $value): bool
+    {
+        foreach ($this->items as $item) {
+            if (strcasecmp($item->getValue(), trim($value)) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $value
+     * @return AcceptHeaderItem|null
+     */
+    public function get(string $value): ?AcceptHeaderItem
+    {
+        foreach ($this->items as $item) {
+            if (strcasecmp($item->getValue(), trim($value)) === 0) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return AcceptHeaderItem[]
+     */
+    public function all(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * @return AcceptHeaderItem[]
+     */
+    public function sorted(): array
+    {
+        $this->sort();
+
+        return $this->items;
+    }
+
+    /**
+     * Add new item to list.
+     *
+     * @param AcceptHeaderItem|string $item
+     */
+    private function addItem($item)
+    {
+        $this->items[] = $item instanceof AcceptHeaderItem ? $item : AcceptHeaderItem::fromString((string) $item);
+        $this->sorted = false;
+    }
+
+    /**
+     * Sort header items by weight.
+     */
+    private function sort()
+    {
+        if (!$this->sorted) {
+            /**
+             * Sort item in descending order.
+             */
+            usort($this->items, function (AcceptHeaderItem $a, AcceptHeaderItem $b) {
+                return AcceptHeaderItem::compare($a, $b) * -1;
+            });
+
+            $this->sorted = true;
+        }
+    }
+}

--- a/src/Header/AcceptHeaderItem.php
+++ b/src/Header/AcceptHeaderItem.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Pavel Z
+ */
+
+declare(strict_types=1);
+
+namespace Spiral\Http\Header;
+
+/**
+ * Represents "Accept" header single item.
+ *
+ * Can be used for comparing each item weight or constructing the "Accept" headers.
+ */
+final class AcceptHeaderItem
+{
+    /** @var string|null */
+    private $value;
+
+    /** @var float */
+    private $quality;
+
+    /** @var array */
+    private $params;
+
+    /**
+     * Parse accept header string.
+     *
+     * @param string $string
+     * @return static
+     */
+    public static function fromString(string $string): self
+    {
+        $elements = explode(';', $string);
+
+        $mime = trim((string) array_shift($elements));
+        $quality = 1.0;
+        $params = [];
+
+        foreach ($elements as $element) {
+            $parsed = explode('=', trim($element), 2);
+
+            // Wrong params must be ignored
+            if (count($parsed) !== 2) {
+                continue;
+            }
+
+            $name = trim($parsed[0]);
+            $value = trim($parsed[1]);
+
+            if ($name === 'q') {
+                $quality = floatval($value);
+            } else {
+                $params[$name] = $value;
+            }
+        }
+
+        return new static($mime, $quality, $params);
+    }
+
+    /**
+     * Compare to header items, witch one is preferable.
+     * Return 1 if first value preferable or -1 if second, 0 in case of same weight.
+     *
+     * @param AcceptHeaderItem|string $a
+     * @param AcceptHeaderItem|string $b
+     * @return int
+     */
+    public static function compare($a, $b): int
+    {
+        $a = $a instanceof AcceptHeaderItem ? $a : AcceptHeaderItem::fromString((string) $a);
+        $b = $b instanceof AcceptHeaderItem ? $b : AcceptHeaderItem::fromString((string) $b);
+
+        if ($a->getQuality() === $b->getQuality()) {
+            // If quality are same value with more params has more weight.
+            if (count($a->getParams()) === count($b->getParams())) {
+                // If quality and params then check for specific type or subtype.
+                // Means */* or * has less weight.
+                return static::compareValue($a->getValue(), $b->getValue());
+            }
+
+            return (count($a->getParams()) > count($b->getParams())) ? 1 : -1;
+        }
+
+        return ($a->getQuality() > $b->getQuality()) ? 1 : -1;
+    }
+
+
+    /**
+     * Compare to header item values. More specific types ( with no "*" ) has more value.
+     * Return 1 if first value preferable or -1 if second, 0 in case of same weight.
+     *
+     * @param string $a
+     * @param string $b
+     * @return int
+     */
+    private static function compareValue(string $a, string $b): int
+    {
+        // Check "Accept" headers values with it is type and subtype.
+        if (strpos($a, '/') !== false && strpos($b, '/') !== false) {
+            [$typeA, $subtypeA] = explode('/', $a, 2);
+            [$typeB, $subtypeB] = explode('/', $b, 2);
+
+            if ($typeA === $typeB) {
+                return static::compareAsterisk($subtypeA, $subtypeB);
+            }
+
+            return static::compareAsterisk($typeA, $typeB);
+        }
+
+        return static::compareAsterisk($a, $b);
+    }
+
+    /**
+     * @param string $a
+     * @param string $b
+     * @return int
+     */
+    private static function compareAsterisk(string $a, string $b)
+    {
+        return $b === '*' && $a !== '*' ? 1
+            : ($b !== '*' && $a === '*' ? -1 : 0);
+    }
+
+    /**
+     * AcceptHeaderItem constructor.
+     * @param string $mime
+     * @param float $quality
+     * @param array $params
+     */
+    public function __construct(string $mime, float $quality = 1.0, array $params = [])
+    {
+        $this->value = $mime;
+        $this->quality = $quality;
+        $this->params = $params;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        $parts = [$this->getValue()];
+
+        if ($this->quality < 1) {
+            $parts[] = "q=$this->quality";
+        }
+
+        foreach ($this->getParams() as $name => $value) {
+            $parts[] = "$name=$value";
+        }
+
+        return implode('; ', $parts);
+    }
+
+    /**
+     * @param string $value
+     * @return $this
+     */
+    public function withValue(string $value): self
+    {
+        $item = clone $this;
+        $item->value = $value;
+
+        return $item;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param float $quality
+     * @return $this
+     */
+    public function withQuality(float $quality): self
+    {
+        $item = clone $this;
+        $item->quality = $quality;
+
+        return $item;
+    }
+
+    /**
+     * @return float
+     */
+    public function getQuality(): float
+    {
+        return $this->quality;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParams(): array
+    {
+        return $this->params;
+    }
+
+    /**
+     * @param array $params
+     * @return $this
+     */
+    public function withParams(array $params): self
+    {
+        $item = clone $this;
+        $item->params = $params;
+
+        return $item;
+    }
+}

--- a/src/Request/InputManager.php
+++ b/src/Request/InputManager.php
@@ -19,6 +19,7 @@ use Psr\Http\Message\UriInterface;
 use Spiral\Core\Container\SingletonInterface;
 use Spiral\Core\Exception\ScopeException;
 use Spiral\Http\Exception\InputException;
+use Spiral\Http\Header\AcceptHeader;
 
 /**
  * Provides simplistic way to access request input data in controllers and can also be used to
@@ -97,6 +98,14 @@ final class InputManager implements SingletonInterface
      * @var string
      */
     private $prefix = '';
+
+    /**
+     * List of content types that must be considered as JSON.
+     * @var array
+     */
+    private $jsonTypes = [
+        'application/json'
+    ];
 
     /**
      * @param ContainerInterface $container
@@ -240,7 +249,27 @@ final class InputManager implements SingletonInterface
      */
     public function isJsonExpected(): bool
     {
-        return $this->request()->getHeaderLine('Accept') == 'application/json';
+        $acceptHeader = AcceptHeader::fromString($this->request()->getHeaderLine('Accept'));
+        foreach ($this->jsonTypes as $jsonType) {
+            if ($acceptHeader->has($jsonType)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Add new content type that will be considered as JSON.
+     *
+     * @param string $type
+     * @return $this
+     */
+    public function addJsonType(string $type): self
+    {
+        $this->jsonTypes[] = $type;
+
+        return $this;
     }
 
     /**

--- a/tests/Http/AcceptHeaderTest.php
+++ b/tests/Http/AcceptHeaderTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Pavel Z
+ */
+
+declare(strict_types=1);
+
+namespace Spiral\Http\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\Http\Header\AcceptHeader;
+use Spiral\Http\Header\AcceptHeaderItem;
+
+class AcceptHeaderTest extends TestCase
+{
+    public function testHeaderItemCompare()
+    {
+        $this->assertEquals(0, AcceptHeaderItem::compare('', ''));
+        $this->assertEquals(0, AcceptHeaderItem::compare('test', 'test2'));
+        $this->assertEquals(1, AcceptHeaderItem::compare('test', 'test2;q=0.7'));
+        $this->assertEquals(-1, AcceptHeaderItem::compare('test; q=0.7', 'test2'));
+
+        $this->assertEquals(0, AcceptHeaderItem::compare('test; q=0.7', 'test2; q=0.7'));
+        $this->assertEquals(0, AcceptHeaderItem::compare('test; q=0.7', 'test2; q=0.7;p'));
+        $this->assertEquals(0, AcceptHeaderItem::compare('test; q=0.7; test=23', 'test2; q=0.7;p=1'));
+        $this->assertEquals(1, AcceptHeaderItem::compare('test; q=0.7; p=2; st=3', 'test2; q=0.7;p=1'));
+        $this->assertEquals(-1, AcceptHeaderItem::compare('test; q=0.7', 'test2; q=0.7;p=1'));
+
+        $this->assertEquals(1, AcceptHeaderItem::compare(
+            AcceptHeaderItem::fromString('test'),
+            AcceptHeaderItem::fromString('*')
+        ));
+    }
+
+    public function testCompareHeaderItemValue()
+    {
+        $class = (new \ReflectionClass(AcceptHeaderItem::class));
+        $compareValue = $class->getMethod('compareValue');
+        $compareValue->setAccessible(true);
+
+        $this->assertEquals(0, $compareValue->invokeArgs(null, ['', '']));
+        $this->assertEquals(0, $compareValue->invokeArgs(null, ['*', '*']));
+        $this->assertEquals(0, $compareValue->invokeArgs(null, ['UTF-8', 'UTF-8']));
+        $this->assertEquals(1, $compareValue->invokeArgs(null, ['UTF-8', '*']));
+        $this->assertEquals(-1, $compareValue->invokeArgs(null, ['*', 'UTF-8']));
+
+        $this->assertEquals(0, $compareValue->invokeArgs(null, ['*/*', '*/*']));
+        $this->assertEquals(1, $compareValue->invokeArgs(null, ['type/*', '*/*']));
+        $this->assertEquals(1, $compareValue->invokeArgs(null, ['type/subtype', '*/*']));
+        $this->assertEquals(-1, $compareValue->invokeArgs(null, ['*/*', 'type/*']));
+        $this->assertEquals(-1, $compareValue->invokeArgs(null, ['*/*', 'type/subtype']));
+
+        $this->assertEquals(0, $compareValue->invokeArgs(null, ['*/*', '*/*']));
+        $this->assertEquals(0, $compareValue->invokeArgs(null, ['type/*', 'type/*']));
+        $this->assertEquals(1, $compareValue->invokeArgs(null, ['type/subtype', 'type/*']));
+        $this->assertEquals(-1, $compareValue->invokeArgs(null, ['type/*', 'type/subtype']));
+    }
+
+    public function testHeaderItem()
+    {
+        $item = new AcceptHeaderItem('text/html', 0.9, ['t' => 'test']);
+
+        $this->assertEquals('text/html; q=0.9; t=test', $item);
+        $this->assertEquals(0.9, $item->getQuality());
+        $this->assertEquals(['t' => 'test'], $item->getParams());
+
+        $item = $item->withValue('application/json');
+
+        $this->assertEquals('application/json', $item->getValue());
+
+        $item = $item->withQuality(0);
+
+        $this->assertEquals(0, $item->getQuality());
+
+        $item = $item->withParams(['n' => 'new']);
+
+        $this->assertEquals(['n' => 'new'], $item->getParams());
+
+        $wrongParamsItem = AcceptHeaderItem::fromString('text/html; q');
+
+        $this->assertEquals([], $wrongParamsItem->getParams());
+        $this->assertEquals(1.0, $wrongParamsItem->getQuality());
+
+        AcceptHeaderItem::fromString('');
+    }
+
+    public function testHeaderConstructing()
+    {
+        $acceptCharset = new AcceptHeader(['*', 'UTF-8']);
+
+        $this->assertFalse($acceptCharset->has('unicode'));
+        $this->assertNull($acceptCharset->get('unicode'));
+
+        $sorted = $acceptCharset->sorted();
+        $this->assertEquals('UTF-8', $sorted[0]);
+        $this->assertEquals('*', $sorted[1]);
+        $this->assertEquals('UTF-8, *', $acceptCharset);
+
+        $acceptCharset = $acceptCharset->add(AcceptHeaderItem::fromString('unicode'));
+
+        $this->assertTrue($acceptCharset->has('unicode'));
+        $this->assertNotNull($acceptCharset->get('unicode'));
+
+        $sorted = $acceptCharset->sorted();
+        $this->assertEquals('UTF-8', $sorted[0]);
+        $this->assertEquals('unicode', $sorted[1]);
+        $this->assertEquals('*', $sorted[2]);
+        $this->assertEquals('UTF-8, unicode, *', $acceptCharset);
+
+        $acceptHeader = AcceptHeader::fromString('text/html; q=0.8, */*; q=0.7');
+        $acceptHeader = $acceptHeader->add('application/json');
+
+        $sorted = $acceptHeader->sorted();
+        $this->assertEquals('application/json', $sorted[0]);
+        $this->assertEquals('text/html; q=0.8', $sorted[1]);
+        $this->assertEquals('*/*; q=0.7', $sorted[2]);
+    }
+
+    public function testHeader1()
+    {
+        $acceptHeader = AcceptHeader::fromString('audio/*; q=0.2, audio/basic')->sorted();
+        $this->assertEquals('audio/basic', (string) $acceptHeader[0]);
+        $this->assertEquals('audio/*; q=0.2', (string) $acceptHeader[1]);
+    }
+
+    public function testHeader2()
+    {
+        $acceptHeader = AcceptHeader::fromString(
+            'text/*;q=0.3, text/html;q=0.7, text/html;level=1, text/html;level=2;q=0.4, */*;q=0.5'
+        )->sorted();
+
+        $this->assertEquals('text/html; level=1', $acceptHeader[0]);
+        $this->assertEquals('text/html; q=0.7', $acceptHeader[1]);
+        $this->assertEquals('*/*; q=0.5', $acceptHeader[2]);
+        $this->assertEquals('text/html; q=0.4; level=2', $acceptHeader[3]);
+        $this->assertEquals('text/*; q=0.3', $acceptHeader[4]);
+    }
+
+    public function testHeader3()
+    {
+        $acceptHeader = AcceptHeader::fromString('text/*, text/html, text/html;level=1, */*')->sorted();
+
+        $this->assertEquals('text/html; level=1', $acceptHeader[0]);
+        $this->assertEquals('text/html', $acceptHeader[1]);
+        $this->assertEquals('text/*', $acceptHeader[2]);
+        $this->assertEquals('*/*', $acceptHeader[3]);
+    }
+
+    public function testHeader4()
+    {
+        $acceptHeader = AcceptHeader::fromString('text, text/html');
+
+        $this->assertEquals('text', (string) $acceptHeader->all()[0]);
+        $this->assertEquals('text/html', (string) $acceptHeader->all()[1]);
+
+        $this->assertEquals('text', (string) $acceptHeader->sorted()[0]);
+        $this->assertEquals('text/html', (string) $acceptHeader->sorted()[1]);
+    }
+}

--- a/tests/Http/InputTest.php
+++ b/tests/Http/InputTest.php
@@ -173,6 +173,20 @@ class InputManagerTest extends TestCase
             'GET',
             'php://input',
             [
+                'Accept' => 'text/html'
+            ]
+        );
+        $this->container->bind(ServerRequestInterface::class, $request);
+
+        $this->assertFalse($this->input->isJsonExpected());
+
+        $request = new ServerRequest(
+            [],
+            [],
+            'http://domain.com/hello-world',
+            'GET',
+            'php://input',
+            [
                 'Accept' => 'application/json'
             ]
         );

--- a/tests/Http/InputTest.php
+++ b/tests/Http/InputTest.php
@@ -153,6 +153,8 @@ class InputManagerTest extends TestCase
 
     public function testIsJsonExpected(): void
     {
+        $this->input->addJsonType('application/vnd.api+json');
+
         $request = new ServerRequest(
             [],
             [],
@@ -188,6 +190,20 @@ class InputManagerTest extends TestCase
             'php://input',
             [
                 'Accept' => 'application/json'
+            ]
+        );
+        $this->container->bind(ServerRequestInterface::class, $request);
+
+        $this->assertTrue($this->input->isJsonExpected());
+
+        $request = new ServerRequest(
+            [],
+            [],
+            'http://domain.com/hello-world',
+            'GET',
+            'php://input',
+            [
+                'Accept' => 'application/vnd.api+json'
             ]
         );
         $this->container->bind(ServerRequestInterface::class, $request);

--- a/tests/Http/ResponsesTest.php
+++ b/tests/Http/ResponsesTest.php
@@ -106,6 +106,13 @@ class ResponsesTest extends TestCase
         $this->assertSame('application/octet-stream', (string)$response->getHeaderLine('Content-Type'));
     }
 
+    public function testCreate()
+    {
+        $response = $this->getWrapper()->create(400);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
     /**
      * @expectedException \Spiral\Http\Exception\ResponseException
      */


### PR DESCRIPTION
Implementation of [RFC7231](https://tools.ietf.org/html/rfc7231#section-5.3.2) "Accept" header parser.

Will be used for fixing next issue:
https://github.com/spiral/framework/issues/231